### PR TITLE
update kontent sdk to kontent.ai

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, OnInit } from '@angular/core';
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { ContentItemModels, LanguageVariantModels, ManagementClient, SharedModels } from '@kentico/kontent-management';
+import { ContentItemModels, LanguageVariantModels, ManagementClient, SharedModels } from '@kontent-ai/management-sdk';
 import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { CoreComponent } from './core/core.component';

--- a/src/app/dialogs/items-preview-dialog.component.ts
+++ b/src/app/dialogs/items-preview-dialog.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ContentItemModels, LanguageVariantModels, ManagementClient, SharedModels } from '@kentico/kontent-management';
+import { ContentItemModels, LanguageVariantModels, ManagementClient, SharedModels } from '@kontent-ai/management-sdk';
 import { ManagementService } from '../services/management.service';
 
 export interface IItemsPreviewDialogData {

--- a/src/app/services/management.service.ts
+++ b/src/app/services/management.service.ts
@@ -7,7 +7,7 @@ import {
     ManagementClient,
     SharedModels,
     WorkflowModels
-} from '@kentico/kontent-management';
+} from '@kontent-ai/management-sdk';
 import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 


### PR DESCRIPTION
Hi Ilesh. I don't seem to have write access to the repo so here a PR from my fork.

There didn't seem to be much to do there, the package.json already specified the newer kontent.ai api but a few of the components were still asking for the old one. Got it working on the Content Tool App environemnt and it looks to be working fine, translated a bunch of stuff.

The other changes were a dead end, I'll explain in more detail in the ticket.